### PR TITLE
Add typings to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "files": [
     "es",
     "lib",
-    "umd"
+    "umd",
+    "index.d.ts"
   ],
   "keywords": [
     "i18next",


### PR DESCRIPTION
When the typings aren't packaged, then typescript cannot find the
typings when the package is used as dependency.

Fixes #6 