### PR TITLE
add ability to optionally skip ploc-ing text inside HTML tags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,7 @@ declare module "i18next-pseudo" {
     letters?: Record<string, string>;
     repeatedLetters?: Array<string>;
     uglifedLetterObject?: Record<string, string>;
+    uglifyHTMLTags?: boolean;
     wrapped?: boolean;
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "clean": "nwb clean-module",
     "test": "nwb test",
     "test:coverage": "nwb test --coverage",
-    "test:watch": "nwb test --server"
+    "test:watch": "nwb test --server",
+    "prepare": "nwb build-web-module"
   },
   "dependencies": {
     "i18next": "^19.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export default class Pseudo {
     uglifedLetterObject = uglifiedAlphabet,
     wrapped = false,
     enabled = true,
+    uglifyHTMLTags = true
   } = {}) {
     this.name = `pseudo`;
     this.type = `postProcessor`;
@@ -18,6 +19,7 @@ export default class Pseudo {
       repeatedLetters,
       letters: uglifedLetterObject,
       enabled,
+      uglifyHTMLTags
     }
   }
 
@@ -29,19 +31,20 @@ export default class Pseudo {
     if ((translator.language && this.options.languageToPseudo !== translator.language) || !this.options.enabled) {
       return value;
     }
-    let bracketCount = 0;
+    let curlyBracketCount = 0;
+    let angleBracketCount = 0;
     const processedValue = value
       .split('')
       .map(letter => {
-        if (letter === '}') {
-          bracketCount = 0;
-          return letter;
+        switch (letter) {
+          case '}': curlyBracketCount--; return letter;
+          case '{': curlyBracketCount++; return letter;
+          case '>': angleBracketCount--; return letter;
+          case '<': angleBracketCount++; return letter;
         }
-        if (letter === '{') {
-          bracketCount++;
-          return letter;
-        }
-        if (bracketCount === 2) return letter;
+
+        if (curlyBracketCount === 2) return letter;
+        if (angleBracketCount > 0 && !this.options.uglifyHTMLTags) return letter;
 
         return this.options.repeatedLetters.indexOf(letter) !== -1
           ? this.options.letters[letter].repeat(this.options.letterMultiplier)


### PR DESCRIPTION
adds new option, `uglifyHTMLTags`, which defaults to off and uses similar handling to braces to skip uglifying text inside HTML tags.